### PR TITLE
fix: add selection for competition and handle special results

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -5,12 +5,15 @@ from bs4 import BeautifulSoup
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 XPATH_LOGIN_AUSWAHL = '/html/body/div/div/form[1]/div/input'
 XPATH_ANZEIGEN_HTML = '//*[@id="content"]/table/tbody/tr/td/table/tbody/tr/td[2]/table/tbody/tr[13]/td/form[2]/input[2]'
 XPATH_RUNDEN_ID = '//*[@id="content"]/table/tbody/tr/td/table/tbody/tr/td[2]/table/tbody/tr[8]/td[2]/select'
+XPATH_RKW_ID = '//*[@id="content"]/table/tbody/tr/td/table/tbody/tr/td[2]/table/tbody/tr[3]/td[2]/select'
 
-def download_html():
+def download_html(rwk_sportyear, association, rwk_id):
     """ Downloads the HTML of the RWK shooting website. """
     driver = webdriver.Chrome()
     driver.get('https://www.rwk-shooting.de/drucken/index.php')
@@ -22,18 +25,33 @@ def download_html():
 
     driver.find_element(By.XPATH, XPATH_LOGIN_AUSWAHL).click()
 
+    select_element = driver.find_element(By.NAME, "rwk_sportjahr")
+    select = Select(select_element)
+    select.select_by_value(str(rwk_sportyear))
+
+    select_element = driver.find_element(By.NAME, "rwk_id")
+    select = Select(select_element)
+    select.select_by_value(str(rwk_id))
+
     select_element = driver.find_element(By.NAME, "verein_id")
     select = Select(select_element)
-    select.select_by_value("SV Wappersdorf:1")
+    select.select_by_value(association)
 
     file_names = []
 
-    # get all rounds
+    # Get RWK ID - Rudenwettkampf - for the filename
+    select_element = driver.find_element(By.XPATH, XPATH_RKW_ID)
+    select = Select(select_element)
+    select_options = select.all_selected_options
+    rwk_id_value = select_options[0].accessible_name
+
+    # get the number of all round in the selected RWK ID for the iteration
     select_element = driver.find_element(By.XPATH, XPATH_RUNDEN_ID)
     select = Select(select_element)
     cnt_rounds = len(select.options)
 
     for i in range(0, cnt_rounds-1):
+        # Get Runden ID for the file name
         select_element = driver.find_element(By.XPATH, XPATH_RUNDEN_ID)
         select = Select(select_element)
         select_options = select.options
@@ -41,11 +59,10 @@ def download_html():
         select.select_by_value(round_value)
 
         driver.find_element(By.XPATH, XPATH_ANZEIGEN_HTML).click()
-
-        driver.switch_to.frame("drucken")
+        WebDriverWait(driver, 10).until(EC.frame_to_be_available_and_switch_to_it((By.NAME, "drucken")))
         iframe_soup = BeautifulSoup(driver.page_source, 'html.parser')
         os.makedirs('temp', exist_ok=True)
-        file_names.append(f"temp/{round_value.replace(':','_').lower()}.html")
+        file_names.append(f"temp/{rwk_id_value.replace(' - ','_').lower()}_{round_value.replace(':','_').lower()}.html")
         with open(file_names[len(file_names)-1], "w", encoding="utf-8") as file:
             file.write(iframe_soup.prettify())
 
@@ -54,6 +71,3 @@ def download_html():
     driver.close()
 
     return file_names
-
-if __name__ == '__main__':
-    download_html()

--- a/main.py
+++ b/main.py
@@ -5,9 +5,13 @@ import collector
 from xlsx_report import XLSXReport
 from result_parser import ResultParser
 from md_report import MDReport
+from src.consts.rwk_shooting_ids import RWKID, ASSOCIATION
 
 # Download the HTML content
-html_result = collector.download_html()
+html_result_LG = collector.download_html(2025, ASSOCIATION.SV_WAPPERSDORF_101052.value, RWKID.LUFTGEWEHR_2025.value)
+html_result_LP = collector.download_html(2025, ASSOCIATION.SV_WAPPERSDORF_101052.value, RWKID.LUFTPISTOLE_2025.value)
+html_result = html_result_LG + html_result_LP
+print(f"Downloaded {len(html_result)} HTML files.")
 
 for html in html_result:
     # Parse the HTML content

--- a/src/consts/rwk_shooting_ids.py
+++ b/src/consts/rwk_shooting_ids.py
@@ -1,0 +1,19 @@
+""" RWK IDs for selection of classes in the rwk-shooting website. """
+from enum import Enum
+
+class RWKID(Enum):
+    """ RWK IDs for selection of classes in the rwk-shooting website. """
+    LUFTGEWEHR_2025 = 1905
+    LUFTPISTOLE_2025 = 1926
+    LUFTGEWEHR_2024 = 1812
+    LUFTPISTOLE_2024 = 1813
+
+class CLASSID(Enum):
+    """ Class IDs for selection of classes in the rwk-shooting website. """
+    OFFENE_KLASSE = "Offene Klasse"
+    ALTERSKLASSE = "Altersklasse"
+    JUGENDLKLASSE = "Jugendklasse"
+
+class ASSOCIATION(Enum):
+    """ Association IDs for selection of classes in the rwk-shooting website. """
+    SV_WAPPERSDORF_101052 = "SV Wappersdorf:1"

--- a/src/models/competition.py
+++ b/src/models/competition.py
@@ -9,9 +9,10 @@ class Competition:
         self.away_team = away_team
         self.result = result
         # Check if the result is in the format 'x:y'
-        if re.match(r'\d+:\d+', self.result):
-            self.home_score = int(result.split(":")[0])
-            self.away_score = int(result.split(":")[1])
+        match = re.match(r'(\d+):(\d+)', self.result)
+        if match:
+            self.home_score = int(match.group(1))
+            self.away_score = int(match.group(2))
         else:
             self.home_score = "N/A"
             self.away_score = "N/A"


### PR DESCRIPTION
Added a selection in rwk-shooting for rwk_id, year and association with enums. 

For competitions where one competitor was not there, the result was tagged with "0 (NA)" - this was fixed to use only the result value as int from regex. 
